### PR TITLE
Mapeos de relay en los componentes para fetcheo de datos

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,7 @@
 {
   "presets": ["es2015", "stage-1", "react"],
-  "plugins": ["react-hot-loader/babel"]
+  "plugins": [
+    "react-hot-loader/babel",
+    "./build/babelRelayPlugin"
+  ]
 }

--- a/build/babelRelayPlugin.js
+++ b/build/babelRelayPlugin.js
@@ -1,0 +1,4 @@
+const getbabelRelayPlugin = require('babel-relay-plugin');
+const schema = require('../schema.json');
+
+module.exports = getbabelRelayPlugin(schema.data);

--- a/client/App/MainContent/index.jsx
+++ b/client/App/MainContent/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Relay from 'react-relay';
 import { Match, Miss } from 'react-router';
 
 import Home from 'screens/Home';
@@ -9,19 +10,80 @@ import NotFound from 'screens/NotFound';
 
 const MainContent = () => (
   <div>
-    <Match exactly pattern="/" component={Home} />
+    <Match
+      exactly
+      pattern="/"
+      render={matchProps => (
+        <Relay.Renderer
+          environment={Relay.Store}
+          Container={Home}
+          queryConfig={{
+            name: 'HomeQueries',
+            queries: {
+              viewer: () => Relay.QL`
+                query { viewer }
+              `
+            },
+            params: {}
+          }}
+          render={({ props }) => (
+            props ? <Home {...matchProps} {...props} /> : undefined
+          )}
+        />
+      )}
+    />
     <Match
       exactly
       pattern="/talk/:id"
-      render={(matchProps) => {
-        const Component = matchProps.params.id === 'new' ?
-          NewTalk :
-          Talk;
-
-        return <Component {...matchProps} />;
-      }}
+      render={matchProps => (
+        matchProps.params.id === 'new' ? (
+          <NewTalk {...matchProps} />
+        ) : (
+          <Relay.Renderer
+            environment={Relay.Store}
+            Container={Talk}
+            queryConfig={{
+              name: 'TalkQueries',
+              queries: {
+                talk: () => Relay.QL`
+                  query { node(id: $talkId) }
+                `
+              },
+              params: {
+                talkId: matchProps.params.id
+              }
+            }}
+            render={({ props }) => (
+              props ? <Talk {...matchProps} {...props} /> : undefined
+            )}
+          />
+        )
+      )}
     />
-    <Match exactly pattern="/speaker/:id" component={Speaker} />
+    <Match
+      exactly
+      pattern="/speaker/:id"
+      render={matchProps => (
+        <Relay.Renderer
+          environment={Relay.Store}
+          Container={Speaker}
+          queryConfig={{
+            name: 'SpeakerQueries',
+            queries: {
+              speaker: () => Relay.QL`
+                query { node(id: $speakerId) }
+              `
+            },
+            params: {
+              speakerId: matchProps.params.id
+            }
+          }}
+          render={({ props }) => (
+            props ? <Speaker {...matchProps} {...props} /> : undefined
+          )}
+        />
+      )}
+    />
     <Miss component={NotFound} />
   </div>
 );

--- a/client/screens/Home/index.jsx
+++ b/client/screens/Home/index.jsx
@@ -1,29 +1,79 @@
 import React from 'react';
-import * as db from 'db';
+import Relay from 'react-relay';
 
 import SpeakerList from 'shared/SpeakerList';
 import TalkList from 'shared/TalkList';
 
 
-const SpeakersSection = () => (
+let SpeakersSection = ({ viewer }) => (
   <div>
     <h1>Oradores</h1>
-    <SpeakerList speakers={db.getSpeakers()} />
+    <SpeakerList speakers={viewer.speakers.edges.map(e => e.node)} />
   </div>
 );
 
-const TalksSection = () => (
+SpeakersSection = Relay.createContainer(SpeakersSection, {
+  fragments: {
+    viewer: () => Relay.QL`
+      fragment on User {
+        speakers(first: 10) {
+          edges {
+            node {
+              id
+              firstName
+              lastName
+            }
+          }
+        }
+      }
+    `
+  }
+});
+
+let TalksSection = ({ viewer }) => (
   <div>
     <h1>Charlas</h1>
-    <TalkList talks={db.getTalks()} />
+    <TalkList talks={viewer.talks.edges.map(e => e.node)} />
   </div>
 );
 
-const MainScreen = () => (
+TalksSection = Relay.createContainer(TalksSection, {
+  fragments: {
+    viewer: () => Relay.QL`
+      fragment on User {
+        talks(first: 10) {
+          edges {
+            node {
+              id
+              title
+              description
+              event {
+                eventSeries {
+                  title
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+  }
+});
+
+const HomeScreen = ({ viewer }) => (
   <div>
-    <SpeakersSection />
-    <TalksSection />
+    <SpeakersSection viewer={viewer} />
+    <TalksSection viewer={viewer} />
   </div>
 );
 
-export default MainScreen;
+export default Relay.createContainer(HomeScreen, {
+  fragments: {
+    viewer: () => Relay.QL`
+      fragment on User {
+        ${SpeakersSection.getFragment('viewer')}
+        ${TalksSection.getFragment('viewer')}
+      }
+    `
+  }
+});

--- a/client/screens/Speaker/index.jsx
+++ b/client/screens/Speaker/index.jsx
@@ -1,20 +1,40 @@
 import React from 'react';
-import * as db from 'db';
+import Relay from 'react-relay';
 
 import TalkList from 'shared/TalkList';
 
 
-const SpeakerScreen = ({ params: { id } }) => {
-  const speaker = db.getSpeakerByIdWithTalks(id);
+const SpeakerScreen = ({ speaker }) => (
+  <div>
+    <h1>{speaker.firstName} {speaker.lastName}</h1>
+    <p>{speaker.bio}</p>
+    <h2>Charlas</h2>
+    <TalkList talks={speaker.talks.edges.map(e => e.node)} />
+  </div>
+);
 
-  return (
-    <div>
-      <h1>{speaker.first_name} {speaker.last_name}</h1>
-      <p>{speaker.bio}</p>
-      <h2>Charlas</h2>
-      <TalkList talks={speaker.talks} />
-    </div>
-  );
-};
-
-export default SpeakerScreen;
+export default Relay.createContainer(SpeakerScreen, {
+  fragments: {
+    speaker: () => Relay.QL`
+      fragment on Speaker {
+        firstName
+        lastName
+        bio
+        talks(first: 10) {
+          edges {
+            node {
+              id
+              title
+              description
+              event {
+                eventSeries {
+                  title
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+  }
+});

--- a/client/screens/Talk/index.jsx
+++ b/client/screens/Talk/index.jsx
@@ -1,20 +1,31 @@
 import React from 'react';
-import * as db from 'db';
+import Relay from 'react-relay';
 
 import SpeakerList from 'shared/SpeakerList';
 
 
-const TalkScreen = ({ params: { id } }) => {
-  const talk = db.getTalkByIdWithSpeakers(id);
+const TalkScreen = ({ talk }) => (
+  <div>
+    <h1>{talk.title}</h1>
+    <p>{talk.description}</p>
+    <h2>Oradores</h2>
+    <SpeakerList speakers={talk.speakers} />
+  </div>
+);
 
-  return (
-    <div>
-      <h1>{talk.title}</h1>
-      <p>{talk.description}</p>
-      <h2>Oradores</h2>
-      <SpeakerList speakers={talk.speakers} />
-    </div>
-  );
-};
-
-export default TalkScreen;
+export default Relay.createContainer(TalkScreen, {
+  initialVariables: { talkId: null },
+  fragments: {
+    talk: () => Relay.QL`
+      fragment on Talk {
+        title
+        description
+        speakers {
+          id
+          firstName
+          lastName
+        }
+      }
+    `
+  }
+});

--- a/client/shared/SpeakerList/index.jsx
+++ b/client/shared/SpeakerList/index.jsx
@@ -8,10 +8,10 @@ const SpeakerCard = ({ speaker }) => (
     <div className={styles.card}>
       <div
         className={styles.picture}
-        style={{ backgroundImage: `url("http://placehold.it/300x300?text=${speaker.first_name}")` }}
+        style={{ backgroundImage: `url("http://placehold.it/300x300?text=${speaker.firstName}")` }}
       />
       <div className={styles.fullName}>
-        {speaker.first_name} {speaker.last_name}
+        {speaker.firstName} {speaker.lastName}
       </div>
     </div>
   </Link>

--- a/client/shared/TalkList/index.jsx
+++ b/client/shared/TalkList/index.jsx
@@ -8,7 +8,7 @@ const TalkItem = ({ talk }) => (
     <div className={styles.item}>
       <div
         className={styles.logo}
-        style={{ backgroundImage: `url("http://placehold.it/300x300?text=${talk.event.event_series.title}")` }}
+        style={{ backgroundImage: `url("http://placehold.it/300x300?text=${talk.event.eventSeries.title}")` }}
       />
       <div className={styles.content}>
         <div className={styles.title}>

--- a/db.js
+++ b/db.js
@@ -1,31 +1,31 @@
 const speakers = {
   1: {
     id: 1,
-    first_name: 'Everette',
-    last_name: 'Brekke',
+    firstName: 'Everette',
+    lastName: 'Brekke',
     nickname: 'juwan.schumm',
-    github_handle: 'juwan.schumm',
-    twitter_handle: 'juwan.schumm',
+    githubHandle: 'juwan.schumm',
+    twitterHandle: 'juwan.schumm',
     website: 'http://Mariana.org/',
     bio: 'Neque blanditiis illum consequuntur amet perspiciatis magni. Aut amet expedita dolore molestias incidunt corporis quis et. Iure quis repudiandae itaque similique vitae temporibus asperiores.'
   },
   2: {
     id: 2,
-    first_name: 'Jaeden',
-    last_name: 'Bashirian',
+    firstName: 'Jaeden',
+    lastName: 'Bashirian',
     nickname: 'kaela.gerlach',
-    github_handle: 'kaela.gerlach',
-    twitter_handle: 'kaela.gerlach',
+    githubHandle: 'kaela.gerlach',
+    twitterHandle: 'kaela.gerlach',
     website: 'http://Little.name/',
     bio: 'Commodi est qui ea ipsam numquam provident repudiandae. Quia nam voluptate ut assumenda hic. Accusamus nam recusandae autem sapiente quod sequi reiciendis veritatis.'
   },
   3: {
     id: 3,
-    first_name: 'Kallie',
-    last_name: 'Hayes',
+    firstName: 'Kallie',
+    lastName: 'Hayes',
     nickname: 'flatley.tyshawn',
-    github_handle: 'flatley.tyshawn',
-    twitter_handle: 'flatley.tyshawn',
+    githubHandle: 'flatley.tyshawn',
+    twitterHandle: 'flatley.tyshawn',
     website: 'http://www.Mayer.ca/',
     bio: 'Dicta nostrum quam ut est natus. Quis placeat et velit totam. Aut fuga veritatis sapiente nihil sit dolore et dolorum.'
   }
@@ -57,80 +57,61 @@ const talks = {
 
 const events = {
   1: {
+    id: 1,
     title: 'Mollitia debitis ipsa',
     start: '2016-06-22',
     end: '1995-02-13',
     location: '0592 Kristin Crossing Suite 970\nEast Carlo, VA 87117',
-    event_series: 1
+    eventSeries: 1
   },
   2: {
+    id: 2,
     title: 'Qui fugiat',
     start: '1983-06-06',
     end: '1991-02-12',
     location: '9960 Audra Mountains\nNew Sylvester, WA 95217',
-    event_series: 1
+    eventSeries: 1
   },
   3: {
+    id: 3,
     title: 'Esse incidunt',
     start: '1982-12-25',
     end: '2002-10-02',
     location: '651 Collins Divide Suite 750\nSimonisborough, OR 20098-2162',
-    event_series: 2
+    eventSeries: 2
   }
 };
 
 const eventSeries = {
   1: {
+    id: 1,
     title: 'Meetup.js'
   },
   2: {
+    id: 2,
     title: 'BANode'
   }
 };
 
 const getEventSeriesById = id => eventSeries[id];
 
-const getEventById = id => ({
-  ...events[id],
-  event_series: getEventSeriesById(events[id].event_series)
-});
+const getEventById = id => events[id];
 
-const getTalkById = id => ({
-  ...talks[id],
-  event: getEventById(talks[id].event)
-});
+const getTalkById = id => talks[id];
 
 const getSpeakerById = id => speakers[id];
 
+module.exports = {
+  getSpeakers: () => (
+    Object.keys(speakers).map(getSpeakerById)
+  ),
+  getTalks: () => (
+    Object.keys(talks).map(getTalkById)
+  ),
 
-export const getSpeakers = () => (
-  Object.keys(speakers).map(getSpeakerById)
-);
-export const getTalks = () => (
-  Object.keys(talks).map(getTalkById)
-);
+  getTalkById,
 
-const getTalksForSpeaker = id => (
-  Object.keys(talks).reduce((talksForSpeaker, talkId) => {
-    const talk = getTalkById(talkId);
-
-    if (talk.speakers.includes(Number(id))) {
-      talksForSpeaker.push(talk);
-    }
-
-    return talksForSpeaker;
-  }, [])
-);
-
-export const getTalkByIdWithSpeakers = (id) => {
-  const talk = getTalkById(id);
-  return {
-    ...talk,
-    speakers: talk.speakers.map(getSpeakerById)
-  };
+  getSpeakerById,
+  getEventById,
+  getEventSeriesById
 };
-
-export const getSpeakerByIdWithTalks = id => ({
-  ...getSpeakerById(id),
-  talks: getTalksForSpeaker(id)
-});

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/GraphqlBA/oradorapp#readme",
   "dependencies": {
     "babel-core": "^6.18.2",
+    "babel-relay-plugin": "^0.9.3",
     "body-parser": "^1.15.2",
     "bookshelf": "^0.10.2",
     "express": "^4.14.0",
@@ -37,6 +38,7 @@
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
     "react-hot-loader": "v3.0.0-beta.6",
+    "react-relay": "^0.9.3",
     "react-router": "v4.0.0-alpha.6",
     "sqlite3": "^3.1.8"
   },

--- a/schema.json
+++ b/schema.json
@@ -13,6 +13,22 @@
           "description": "",
           "fields": [
             {
+              "name": "viewer",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "User",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "node",
               "description": "",
               "args": [
@@ -38,11 +54,32 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
-            },
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "User",
+          "description": "",
+          "fields": [
             {
               "name": "speakers",
               "description": "",
               "args": [
+                {
+                  "name": "query",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
                 {
                   "name": "after",
                   "description": "",
@@ -85,9 +122,80 @@
                 }
               ],
               "type": {
-                "kind": "OBJECT",
-                "name": "SpeakerConnection",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SpeakerConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "talks",
+              "description": "",
+              "args": [
+                {
+                  "name": "query",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "after",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TalkConnection",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -97,64 +205,6 @@
           "interfaces": [],
           "enumValues": null,
           "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "ID",
-          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INTERFACE",
-          "name": "Node",
-          "description": "",
-          "fields": [
-            {
-              "name": "id",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": [
-            {
-              "kind": "OBJECT",
-              "name": "Speaker",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "Talk",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "Event",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "EventSeries",
-              "ofType": null
-            }
-          ]
         },
         {
           "kind": "SCALAR",
@@ -374,6 +424,63 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "talks",
+              "description": "",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TalkConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -384,6 +491,627 @@
               "ofType": null
             }
           ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "Node",
+          "description": "",
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Speaker",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Talk",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Event",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "EventSeries",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ID",
+          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TalkConnection",
+          "description": "",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TalkEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TalkEdge",
+          "description": "",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Talk",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Talk",
+          "description": "The talk a speaker gave at an event.",
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "topics",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "speakers",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Speaker",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "event",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Event",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Event",
+          "description": "The instance of a meetup or conf. It contains the dates and location it happens.",
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "start",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "end",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "location",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "talks",
+              "description": "",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TalkConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eventSeries",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "EventSeries",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "DateTime",
+          "description": "",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EventSeries",
+          "description": "The entity that groups a set of events. This is basically the conf or meetup itself.",
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "events",
+              "description": "",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "EventConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EventConnection",
+          "description": "",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "EventEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EventEdge",
+          "description": "",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Event",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -1300,479 +2028,6 @@
               "deprecationReason": null
             }
           ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "DateTime",
-          "description": "",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "TalkEdge",
-          "description": "",
-          "fields": [
-            {
-              "name": "cursor",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "node",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Talk",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "Talk",
-          "description": "The talk a speaker gave at an event.",
-          "fields": [
-            {
-              "name": "id",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "title",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "description",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "topics",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "speakers",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "Speaker",
-                    "ofType": null
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "event",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Event",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "Node",
-              "ofType": null
-            }
-          ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "Event",
-          "description": "The instance of a meetup or conf. It contains the dates and location it happens.",
-          "fields": [
-            {
-              "name": "id",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "title",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "start",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "DateTime",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "end",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "location",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "talks",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "TalkConnection",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "eventSeries",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "EventSeries",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "Node",
-              "ofType": null
-            }
-          ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "TalkConnection",
-          "description": "",
-          "fields": [
-            {
-              "name": "edges",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "TalkEdge",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "pageInfo",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "PageInfo",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "EventSeries",
-          "description": "The entity that groups a set of events. This is basically the conf or meetup itself.",
-          "fields": [
-            {
-              "name": "id",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "title",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "events",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "EventConnection",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "Node",
-              "ofType": null
-            }
-          ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "EventConnection",
-          "description": "",
-          "fields": [
-            {
-              "name": "edges",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "EventEdge",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "pageInfo",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "PageInfo",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "EventEdge",
-          "description": "",
-          "fields": [
-            {
-              "name": "cursor",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "node",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Event",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
           "possibleTypes": null
         },
         {

--- a/server/schema.js
+++ b/server/schema.js
@@ -98,10 +98,14 @@ type EventSeries implements Node {
   events(${CONNECTION_ARGS}): EventConnection!
 }
 
-type Query {
-  node(id: ID!): Node
+type User {
   speakers(query: String, ${CONNECTION_ARGS}): SpeakerConnection!
   talks(query: String, ${CONNECTION_ARGS}): TalkConnection!
+}
+
+type Query {
+  viewer: User!
+  node(id: ID!): Node
 }
 
 schema {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,6 +54,9 @@ module.exports = {
   },
   resolve: {
     root: rootPath,
+    alias: {
+      db: path.join(__dirname, './db.js')
+    },
     extensions: ['', '.js', '.jsx', '.json', '.css', '.scss']
   },
   plugins: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -877,6 +877,12 @@ babel-register@^6.18.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
+babel-relay-plugin@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/babel-relay-plugin/-/babel-relay-plugin-0.9.3.tgz#4dd92693f68b00cd1cb68a705470f8f9cfaed5d6"
+  dependencies:
+    graphql "^0.6.0"
+
 babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.6.1, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.18.0.tgz#0f4177ffd98492ef13b9f823e9994a02584c9078"
@@ -1947,7 +1953,7 @@ eslint-plugin-import@^2.2.0:
     minimatch "^3.0.3"
     pkg-up "^1.0.0"
 
-eslint-plugin-jsx-a11y@2.2.3:
+eslint-plugin-jsx-a11y@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-2.2.3.tgz#4e35cb71b8a7db702ac415c806eb8e8d9ea6c65d"
   dependencies:
@@ -1962,7 +1968,7 @@ eslint-plugin-react@^6.7.1:
     doctrine "^1.2.2"
     jsx-ast-utils "^1.3.3"
 
-eslint@^3.11.0:
+eslint@^3.11.1:
   version "3.11.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.11.1.tgz#408be581041385cba947cd8d1cd2227782b55dbf"
   dependencies:
@@ -2485,6 +2491,12 @@ graphql-tools@^0.8.3:
     node-uuid "^1.4.7"
   optionalDependencies:
     typed-graphql "^1.0.2"
+
+graphql@^0.6.0:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.6.2.tgz#19cdcb17e5862d64396a0684f92f7be64e90e7af"
+  dependencies:
+    iterall "1.0.2"
 
 graphql@^0.8.2:
   version "0.8.2"
@@ -4310,6 +4322,14 @@ react-proxy@^3.0.0-alpha.0:
   dependencies:
     lodash "^4.6.1"
 
+react-relay@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/react-relay/-/react-relay-0.9.3.tgz#74ddd8ed2d60fde7303471ada5306342f5db99a6"
+  dependencies:
+    babel-runtime "^6.6.1"
+    fbjs "^0.8.1"
+    react-static-container "^1.0.1"
+
 react-router@v4.0.0-alpha.6:
   version "4.0.0-alpha.6"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.0.0-alpha.6.tgz#239fcf9a6ba7997021022c9b51d72d370f7b6bf4"
@@ -4318,6 +4338,10 @@ react-router@v4.0.0-alpha.6:
     path-to-regexp "^1.5.3"
     query-string "4.2.3"
     react-broadcast "^0.1.2"
+
+react-static-container@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/react-static-container/-/react-static-container-1.0.1.tgz#694c0dd68a896b879519afb548399cc1989c9ab0"
 
 react@^15.4.1:
   version "15.4.1"


### PR DESCRIPTION
Este PR agrega Relay (usando la base en memoria que antes estaba en el cliente y ahora esta usada por el server en los resolvers). Hay cambios en el schema para poder tener las queries y fragments correctos en los componentes en la UI. A partir de ahora solo es cuestion de agregar o sacar campos para mostrar en la UI.

Lo que falta (y lo voy a hacer en un PR despues) es agregar la mutation de agregar una nueva charla.