### PR TITLE
Implementar mutación talkAdd en resolver de DB

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,9 @@
   "rules": {
     "react/prop-types": 0,
     "max-len": 0,
-    "comma-dangle": [2, "never"]
+    "comma-dangle": [2, "never"],
+    "jsx-a11y/label-has-for": 0,
+    "class-methods-use-this": 0
   },
   "env": {
     "es6": true,

--- a/client/screens/NewTalk/index.jsx
+++ b/client/screens/NewTalk/index.jsx
@@ -68,16 +68,16 @@ const FormField = ({ label, children }) => (
       {children}
     </label>
   </div>
-)
+);
 
 
 class NewTalkScreen extends React.Component {
   state = {
     eventId: this.props.viewer.events.edges[0].node.id,
     speakerIds: [this.props.viewer.speakers.edges[0].node.id],
+    topicIds: [],
     title: '',
-    description: '',
-    topics: ''
+    description: ''
   };
 
   isFormDisabled = () => (
@@ -115,7 +115,9 @@ class NewTalkScreen extends React.Component {
 
   handleTopicsChange = (ev) => {
     this.setState({
-      topics: ev.target.value
+      topicIds: [...ev.target.options]
+        .filter(option => option.selected)
+        .map(option => option.value)
     });
   }
 
@@ -128,7 +130,7 @@ class NewTalkScreen extends React.Component {
       viewer: this.props.viewer,
       title: this.state.title,
       description: this.state.description,
-      topics: this.state.topics.split(',').map(t => t.trim()).filter(Boolean),
+      topics: this.state.topicIds,
       speakerIds: this.state.speakerIds,
       eventId: this.state.eventId
     }), {
@@ -193,13 +195,23 @@ class NewTalkScreen extends React.Component {
               onChange={this.handleDescriptionChange}
             />
           </FormField>
-          <FormField label="Agregá etiquetas para catalogar la charla (separadas por comas)">
-            <input
-              type="text"
+          <FormField label="Tópicos relacionados a la charla">
+            <select
               id="tags"
-              value={this.state.topics}
+              value={this.state.topicIds}
+              multiple
               onChange={this.handleTopicsChange}
-            />
+            >
+              {this.props.viewer.topics.edges.map((edge) => {
+                const topic = edge.node;
+
+                return (
+                  <option key={topic.id} value={topic.id}>
+                    {topic.name}
+                  </option>
+                );
+              })}
+            </select>
           </FormField>
           Listo? {
             <button
@@ -235,6 +247,14 @@ export default Relay.createContainer(NewTalkScreen, {
             node {
               id
               title
+            }
+          }
+        }
+        topics(first: 1000) {
+          edges {
+            node {
+              id
+              name
             }
           }
         }

--- a/schema.json
+++ b/schema.json
@@ -284,6 +284,73 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "topics",
+              "description": "",
+              "args": [
+                {
+                  "name": "query",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "after",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TopicConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -346,6 +413,11 @@
             {
               "kind": "OBJECT",
               "name": "EventSeries",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Topic",
               "ofType": null
             }
           ]
@@ -1311,6 +1383,137 @@
           ],
           "inputFields": null,
           "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TopicConnection",
+          "description": "",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TopicEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TopicEdge",
+          "description": "",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Topic",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Topic",
+          "description": "A topic a talk can be related to",
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
           "enumValues": null,
           "possibleTypes": null
         },

--- a/server/connectors/sqlite.js
+++ b/server/connectors/sqlite.js
@@ -2,6 +2,7 @@ const Speaker = require('../db/models/Speaker');
 const Talk = require('../db/models/Talk');
 const Event = require('../db/models/Event');
 const EventSerie = require('../db/models/EventSerie');
+const Topic = require('../db/models/Topic');
 
 const { getPaginatedModel } = require('./util/pagination');
 const { connectionFromCollection, modelToJSON } = require('./util/relay');
@@ -32,6 +33,12 @@ module.exports = {
     );
   },
 
+  getTopics: (args) => {
+    return getPaginatedModel(Topic, args).then(
+      collection => connectionFromCollection(collection, args, 'Topic')
+    );
+  },
+
   getEvents: args => getPaginatedModel(Event, args).then(
     collection => connectionFromCollection(collection, args, 'Event')
   ),
@@ -57,5 +64,13 @@ module.exports = {
 
   getEventById: id => Event.query({ where: { id } }).fetch().then(modelToJSON),
   getEventSeriesById: id => EventSerie.query({ where: { id } }).fetch().then(modelToJSON),
-  addTalk: () => {}
+  getTopicById: id => Topic.query({ where: { id } }).fetch().then(modelToJSON),
+  talkAdd: ({ title, description, eventId, speakerIds }) => (
+    Talk.forge({ title, description, event_id: eventId }).save()
+    .then(
+      talk => talk.related('speakers').attach(speakerIds)
+      .then(() => talk.related('topics').attach([1, 2]))
+    )
+    .then(modelToJSON)
+  )
 };

--- a/server/connectors/sqlite.js
+++ b/server/connectors/sqlite.js
@@ -65,11 +65,11 @@ module.exports = {
   getEventById: id => Event.query({ where: { id } }).fetch().then(modelToJSON),
   getEventSeriesById: id => EventSerie.query({ where: { id } }).fetch().then(modelToJSON),
   getTopicById: id => Topic.query({ where: { id } }).fetch().then(modelToJSON),
-  talkAdd: ({ title, description, eventId, speakerIds }) => (
+  talkAdd: ({ title, description, eventId, speakerIds, topicIds }) => (
     Talk.forge({ title, description, event_id: eventId }).save()
     .then(
       talk => talk.related('speakers').attach(speakerIds)
-      .then(() => talk.related('topics').attach([1, 2]))
+      .then(() => talk.related('topics').attach(topicIds))
     )
     .then(modelToJSON)
   )

--- a/server/connectors/util/pagination.js
+++ b/server/connectors/util/pagination.js
@@ -10,6 +10,6 @@ module.exports = {
       withRelated
     });
   },
-  shouldHaveNextPage: ({ offset, rowCount, pageCount }) => ((rowCount - offset) > pageCount),
+  shouldHaveNextPage: ({ offset, rowCount, limit }) => ((rowCount - offset) >= limit),
   shouldHavePreviousPage: ({ offset, limit }) => (offset > limit)
 };

--- a/server/db/seeds/events.js
+++ b/server/db/seeds/events.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 const casual = require('casual');
-const { resetSequence } = require('./util');
+const { resetSequence, howMany } = require('./util');
 
 function eventFactory() {
   const date = casual.date();
@@ -29,10 +29,10 @@ exports.seed = (knex, Promise) => (
     knex('event_series').del()
   ]).then(() => {
     const promises = [];
-    [...Array(100)].forEach(() => {
+    [...Array(howMany)].forEach(() => {
       promises.push(knex('events').insert(eventFactory()));
     });
-    [...Array(100)].forEach(() => {
+    [...Array(howMany)].forEach(() => {
       promises.push(knex('event_series').insert(eventSeriesFactory()));
     });
 

--- a/server/db/seeds/speakers.js
+++ b/server/db/seeds/speakers.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 const casual = require('casual');
-const { resetSequence } = require('./util');
+const { resetSequence, howMany } = require('./util');
 
 function speakerFactory() {
   const username = casual.username.toLowerCase();
@@ -22,7 +22,7 @@ exports.seed = (knex, Promise) => (
     knex('speakers').del()
   ]).then(() => {
     const promises = [];
-    [...Array(100)].forEach(() => {
+    [...Array(howMany)].forEach(() => {
       promises.push(knex('speakers').insert(speakerFactory()));
     });
 

--- a/server/db/seeds/talks.js
+++ b/server/db/seeds/talks.js
@@ -1,13 +1,13 @@
 /* eslint-disable import/no-extraneous-dependencies, camelcase */
 const casual = require('casual');
-const { resetSequence } = require('./util');
+const { resetSequence, howMany } = require('./util');
 const { topics } = require('./topics');
 
 function talkFactory() {
   return {
     title: casual.sentence,
     description: casual.sentences(4),
-    event_id: casual.integer(1, 100)
+    event_id: casual.integer(1, howMany)
   };
 }
 
@@ -19,10 +19,10 @@ exports.seed = (knex, Promise) => (
     knex('speakers_talks').del()
   ]).then(() => {
     const promises = [];
-    [...Array(100)].forEach((_, talk_id) => {
+    [...Array(howMany)].forEach((_, talk_id) => {
       promises.push(knex('talks').insert(talkFactory()));
       [...Array(casual.integer(1, 3))].forEach(() => {
-        const speaker_id = casual.integer(1, 100);
+        const speaker_id = casual.integer(1, howMany);
         promises.push(knex('speakers_talks').insert({ speaker_id, talk_id }));
       });
       [...Array(casual.integer(1, 3))].forEach(() => {

--- a/server/db/seeds/util/index.js
+++ b/server/db/seeds/util/index.js
@@ -1,5 +1,7 @@
 const resetSequence = (knex, table) => knex('sqlite_sequence').where('name', table).del();
+const howMany = 50;
 
 module.exports = {
-  resetSequence
+  resetSequence,
+  howMany
 };

--- a/server/resolvers/db.js
+++ b/server/resolvers/db.js
@@ -19,6 +19,9 @@ const resolvers = {
   EventSeries: {
     id: series => toGlobalId('EventSeries', series.id)
   },
+  Topic: {
+    id: topic => toGlobalId('Topic', topic.id)
+  },
   User: {
     id: () => toGlobalId('User', 1),
     speakers(root, args) {
@@ -29,6 +32,9 @@ const resolvers = {
     },
     events(root, args) {
       return db.getEvents(args);
+    },
+    topics(root, args) {
+      return db.getTopics(args);
     }
   },
   Query: {
@@ -55,6 +61,10 @@ const resolvers = {
         case 'EventSeries':
           return db.getEventSerieById(+id).then(eventSerie => (
             Object.assign({ type: 'EventSerie' }, eventSerie)
+          ));
+        case 'Topic':
+          return db.getTopicById(+id).then(topic => (
+            Object.assign({ type: 'Topic' }, topic)
           ));
         default:
           return null;

--- a/server/resolvers/db.js
+++ b/server/resolvers/db.js
@@ -82,22 +82,22 @@ const resolvers = {
   Mutation: {
     talkAdd(root, args) {
       const { input } = args;
-      const newTalk = db.addTalk({
+      return db.talkAdd({
         title: input.title,
         description: input.description,
-        topics: input.topics,
+        topicIds: input.topicIds.map(topicId => (
+          +fromGlobalId(topicId).id
+        )),
         eventId: +fromGlobalId(input.eventId).id,
         speakerIds: input.speakerIds.map(speakerId => (
           +fromGlobalId(speakerId).id
         ))
-      });
-
-      return {
+      }).then(newTalk => ({
         clientMutationId: input.clientMutationId,
         newTalkId: newTalk.id,
         eventId: input.eventId,
         speakerIds: input.speakerIds
-      };
+      }));
     }
   }
 };

--- a/server/schema/index.js
+++ b/server/schema/index.js
@@ -4,6 +4,7 @@ const Event = require('./types/Event');
 const EventSeries = require('./types/EventSeries');
 const Speaker = require('./types/Speaker');
 const Talk = require('./types/Talk');
+const Topic = require('./types/Topic');
 const User = require('./types/User');
 const Query = require('./Query');
 const Mutation = require('./Mutation');
@@ -28,7 +29,7 @@ schema {
 
 module.exports = makeExecutableSchema({
   typeDefs: [
-    schema, Event, EventSeries, Speaker, Talk, User, Query, Mutation
+    schema, Event, EventSeries, Speaker, Talk, Topic, User, Query, Mutation
   ],
   resolvers
 });

--- a/server/schema/types/Topic.js
+++ b/server/schema/types/Topic.js
@@ -1,0 +1,17 @@
+module.exports = `
+type TopicEdge {
+  cursor: String!
+  node: Topic
+}
+
+type TopicConnection {
+  edges: [TopicEdge]
+  pageInfo: PageInfo!
+}
+
+# A topic a talk can be related to
+type Topic implements Node {
+  id: ID!
+  name: String!
+}
+`;

--- a/server/schema/types/User.js
+++ b/server/schema/types/User.js
@@ -6,5 +6,6 @@ type User implements Node {
   speakers(query: String, ${CONNECTION_ARGS}): SpeakerConnection!
   talks(query: String, ${CONNECTION_ARGS}): TalkConnection!
   events(query: String, ${CONNECTION_ARGS}): EventConnection!
+  topics(query: String, ${CONNECTION_ARGS}): TopicConnection!
 }
 `;


### PR DESCRIPTION
- Modifiqué el form de agregar una charla para que use los topics de la DB y se elijan de la misma manera que los speakers.
- Agregado el `type Topic` junto con su query y resolvers
- Modificación de los seeders para poder cambiar fácil cuántos se generan
- Arreglé la función `shouldHaveNextPage` que tiraba cualquiera 😛 